### PR TITLE
Get action_values using  fb_insights 

### DIFF
--- a/R/fb_init.R
+++ b/R/fb_init.R
@@ -241,7 +241,8 @@ fbad_request <- function(fbacc, path, method = c('GET', 'POST', 'DELETE'), param
             ## log it
             flog.error(paste('This is a temporary',
                              shQuote(res$error$type),
-                             'FB error.'))
+                             'FB error:',
+                             res$error$message))
 
             ## give some chance for the system/network to recover
             Sys.sleep(2)

--- a/R/fb_search.R
+++ b/R/fb_search.R
@@ -54,7 +54,7 @@ fbad_get_search <- function(
         params = params)
 
     ## transform data into data frame
-    res <- fromJSON(properties)$data
+    res <- fromJSON(jsonlite::fromJSON(gsub('\n', '', properties)))$data
 
     ## list to data.frame with know colnames
     if (type %in% c(


### PR DESCRIPTION
How to get specified actions using fb_insights and get offsite_conversion only, for example?
Here is code:
fb_insights(time_range = "{'since':'2017-02-02','until':'2017-02-02'}", level = 'ad', fields = c('actions'))

Now all action types put into one row: http://prntscr.com/e6niz6