### PR TITLE
Fix list custom audiences to prefix with act_

### DIFF
--- a/R/fb_ad.R
+++ b/R/fb_ad.R
@@ -183,7 +183,7 @@ fbad_list_ad <- function(fbacc, id, statuses, fields = 'id') {
     }
 
     ## default ID for current Ad Account
-    if (missing(id) | fn == 'fbad_list_campaign') {
+    if (missing(id) | fn %in% c('fbad_list_campaign', 'fbad_list_audience')) {
         id <- paste0('act_', fbacc$account_id)
     }
 

--- a/R/fb_audience.R
+++ b/R/fb_audience.R
@@ -213,7 +213,7 @@ fbad_create_lookalike_audience <- function(fbacc, name, origin_audience_id, rati
 
 }
 
-#' List all Custom Audiences for Ad account
+#' List all Custom Audiences for current Ad account
 #' @inheritParams fbad_request
 #' @param fields character vector of fields to get from the API, defaults to \code{id}. Please refer to the Facebook documentation for a list of possible values.
 #' @export

--- a/man/fbad_list_audience.Rd
+++ b/man/fbad_list_audience.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fb_audience.R
 \name{fbad_list_audience}
 \alias{fbad_list_audience}
-\title{List all Custom Audiences for Ad account}
+\title{List all Custom Audiences for current Ad account}
 \usage{
 fbad_list_audience(fbacc, id, statuses, fields = "id")
 }
@@ -12,7 +12,7 @@ fbad_list_audience(fbacc, id, statuses, fields = "id")
 \item{fields}{character vector of fields to get from the API, defaults to \code{id}. Please refer to the Facebook documentation for a list of possible values.}
 }
 \description{
-List all Custom Audiences for Ad account
+List all Custom Audiences for current Ad account
 }
 \references{
 \url{https://developers.facebook.com/docs/marketing-api/reference/ad-account/customaudiences/#Reading}


### PR DESCRIPTION
Since /customaudiences is on ad account need to prefix the id with 'act_'